### PR TITLE
Fix compilation error with gcc 4.8.4

### DIFF
--- a/transform/framecombine.h
+++ b/transform/framecombine.h
@@ -59,7 +59,7 @@ protected:
         for (int p=0; p<nump; p++) pixel_cost *= (1 + srcRanges->max(p) - srcRanges->min(p));
         // pixel_cost is roughly the cost per pixel (number of different values a pixel can take)
         if (pixel_cost < 16) return false; // pixels are too cheap, no point in trying to save stuff
-        uint64_t found_pixels[images.size()] {};
+        uint64_t found_pixels[images.size()];
         uint64_t new_pixels=0;
         max_lookback=1;
         if (user_max_lookback == -1) user_max_lookback = images.size()-1;


### PR DESCRIPTION
Without the change, I get this error:

```
transform/framecombine.h: In member function ‘virtual bool TransformFrameCombine::process(const ColorRanges*, const Images&)’:
transform/framecombine.h:62:47: error: variable-sized object ‘found_pixels’ may not be initialized
         uint64_t found_pixels[images.size()] {};

```