### PR TITLE
Abstracted IO into a template parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CXXFLAGS := $(shell pkg-config --cflags zlib libpng)
 LDFLAGS := $(shell pkg-config --libs zlib libpng)
 
-flif: maniac/*.h maniac/*.cpp image/*.h image/*.cpp transform/*.h transform/*.cpp flif.cpp flif-enc.cpp flif-dec.cpp common.cpp flif.h flif-enc.h flif-dec.h common.h flif_config.h
-	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall maniac/util.cpp maniac/chance.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/color_range.cpp transform/factory.cpp flif.cpp common.cpp flif-enc.cpp flif-dec.cpp -o flif $(LDFLAGS) 
+flif: maniac/*.h maniac/*.cpp image/*.h image/*.cpp transform/*.h transform/*.cpp flif.cpp flif-enc.cpp flif-dec.cpp common.cpp flif.h flif-enc.h flif-dec.h common.h flif_config.h fileio.h
+	$(CXX) -std=gnu++11 $(CXXFLAGS) -DNDEBUG -O3 -g0 -Wall maniac/util.cpp maniac/chance.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/color_range.cpp transform/factory.cpp flif.cpp common.cpp flif-enc.cpp flif-dec.cpp -o flif $(LDFLAGS)
 
 flif.prof: maniac/*.h maniac/*.cpp image/*.h image/*.cpp transform/*.h transform/*.cpp flif.cpp flif.h flif_config.h
 	$(CXX) -std=gnu++11 $(CXXFLAGS) $(LDFLAGS) -DNDEBUG -O3 -g0 -pg -Wall maniac/util.cpp maniac/chance.cpp image/crc32k.cpp image/image.cpp image/image-png.cpp image/image-pnm.cpp image/image-pam.cpp image/color_range.cpp transform/factory.cpp flif.cpp common.cpp flif-enc.cpp flif-dec.cpp -o flif.prof

--- a/fileio.h
+++ b/fileio.h
@@ -1,0 +1,51 @@
+#ifndef __FILEIO_H__
+#define __FILEIO_H__
+
+#include <stdio.h>
+
+class FileIO
+{
+private:
+    FILE *file;
+    const char *name;
+public:
+    FileIO(FILE* fil, const char *aname) : file(fil), name(aname) { }
+    int read() {
+        int r = fgetc(file);
+        if (r < 0) return 0;
+        return r;
+    }
+    void write(int byte) {
+        ::fputc(byte, file);
+    }
+    void flush() {
+        fflush(file);
+    }
+    bool isEOF() {
+      return feof(file);
+    }
+    int ftell() {
+      return ::ftell(file);
+    }
+    int getc() {
+      return fgetc(file);
+    }
+    char * gets(char *buf, int n) {
+      return fgets(buf, n, file);
+    }
+    int fputs(const char *s) {
+      return ::fputs(s, file);
+    }
+    int fputc(int c) {
+      return ::fputc(c, file);
+    }
+    void close() {
+      fclose(file);
+      file = NULL;
+    }
+    const char* getName() {
+      return name;
+    }
+};
+
+#endif

--- a/fileio.h
+++ b/fileio.h
@@ -1,5 +1,5 @@
-#ifndef __FILEIO_H__
-#define __FILEIO_H__
+#ifndef FLIF_FILEIO_H
+#define FLIF_FILEIO_H
 
 #include <stdio.h>
 

--- a/flif-dec.h
+++ b/flif-dec.h
@@ -1,6 +1,7 @@
 #ifndef FLIF_DEC_H
 #define FLIF_DEC_H
 
-bool flif_decode(const char* filename, Images &images, int quality, int scale);
+template <typename IO>
+bool flif_decode(IO io, Images &images, int quality, int scale);
 
 #endif

--- a/flif-enc.h
+++ b/flif-enc.h
@@ -4,6 +4,7 @@
 #include "image/color_range.h"
 #include "transform/factory.h"
 
-bool flif_encode(const char* filename, Images &images, std::vector<std::string> transDesc, int encoding, int learn_repeats, int acb, int frame_delay, int palette_size, int lookback);
+template <typename IO>
+bool flif_encode(IO io, Images &images, std::vector<std::string> transDesc, int encoding, int learn_repeats, int acb, int frame_delay, int palette_size, int lookback);
 
 #endif

--- a/flif.cpp
+++ b/flif.cpp
@@ -307,7 +307,9 @@ bool handle_encode_arguments(int argc, char **argv, Images &images, int palette_
         if (nb_pixels < 5000) learn_repeats--;        // avoid large trees for small images
         if (learn_repeats < 0) learn_repeats=0;
     }
-    return flif_encode(argv[0], images, desc, method, learn_repeats, acb, frame_delay, palette_size, lookback);
+    FILE *file = fopen(argv[0],"wb");
+    FileIO fio(file, argv[0]);
+    return flif_encode(fio, images, desc, method, learn_repeats, acb, frame_delay, palette_size, lookback);
 }
 
 int handle_decode_arguments(char **argv, Images &images, int quality, int scale) {
@@ -317,7 +319,11 @@ int handle_decode_arguments(char **argv, Images &images, int quality, int scale)
         fprintf(stderr,"Error: expected \".png\", \".pnm\" or \".pam\" file name extension for output file\n");
         return 1;
     }
-    if (!flif_decode(argv[0], images, quality, scale)) return 3;
+
+    FILE *file = fopen(argv[0],"rb");
+    FileIO fio(file, argv[0]);
+
+    if (!flif_decode(fio, images, quality, scale)) return 3;
     if (scale>1)
         v_printf(3,"Downscaling output: %ux%u -> %ux%u\n",images[0].cols(),images[0].rows(),images[0].cols()/scale,images[0].rows()/scale);
     if (images.size() == 1) {

--- a/flif.h
+++ b/flif.h
@@ -3,16 +3,8 @@
 
 #include "image/image.h"
 
-bool flif_encode(const char* filename, Images &images, std::vector<std::string> transDesc, int encoding, int learn_repeats, int acb, int frame_delay, int palette_size, int lookback);
-bool flif_encode(const char* filename, Images &images) {
-    std::vector<std::string> desc = {"YIQ", "BND", "PLA", "PLT", "ACB", "DUP", "FRS", "FRA"};
-    return flif_encode(filename, images, desc, 2, 3, 1, 100, 512, 1);
-}
-
-bool flif_decode(const char* filename, Images &images, int quality, int scale);
-bool flif_decode(const char* filename, Images &images) {
-    return flif_decode(filename, images, 100, 1);
-}
+#include "flif-enc.h"
+#include "flif-dec.h"
 
 bool handle_encode_arguments(int argc, char **argv, Images &images, int palette_size, int acb, int method, int lookback, int learn_repeats, int frame_delay);
 int handle_decode_arguments(char **argv, Images &images, int quality, int scale);

--- a/flif_config.h
+++ b/flif_config.h
@@ -13,8 +13,15 @@
 
 
 #include "maniac/rac.h"
-typedef RacInput40 RacIn;
-typedef RacOutput40 RacOut;
+
+#include "fileio.h"
+
+template <typename IO>
+using RacIn = RacInput40<IO>;
+
+template <typename IO>
+using RacOut = RacOutput40<IO>;
+
 //typedef RacInput24 RacIn;
 //typedef RacOutput24 RacOut;
 

--- a/maniac/rac.h
+++ b/maniac/rac.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <assert.h>
 
-
 /* RAC configuration for 40-bit RAC */
 class RacConfig40
 {
@@ -91,9 +90,15 @@ public:
     int ftell() {
       return io.ftell();
     }
+    char getc() {
+      return io.getc();
+    }
+    char * gets(char *buf, int n) {
+      return io.gets(buf, n);
+    }
 };
 
-template <class Config, class IO> class RacOutput
+template <class Config, typename IO> class RacOutput
 {
 public:
     typedef typename Config::data_t rac_t;
@@ -198,53 +203,28 @@ public:
     }
 };
 
-
-class RacFileIO
+template <typename IO> class RacInput40 : public RacInput<RacConfig40, IO>
 {
-private:
-    FILE *file;
 public:
-    RacFileIO(FILE* fil) : file(fil) { }
-    int read() {
-        int r = fgetc(file);
-        if (r < 0) return 0;
-        return r;
-    }
-    void write(int byte) {
-        fputc(byte, file);
-    }
-    void flush() {
-    }
-    bool isEOF() {
-      return feof(file);
-    }
-    int ftell() {
-      return ::ftell(file);
-    }
+    RacInput40(IO io) : RacInput<RacConfig40, IO>(io) { }
 };
 
-class RacInput40 : public RacInput<RacConfig40, RacFileIO>
+template <typename IO> class RacOutput40 : public RacOutput<RacConfig40, IO>
 {
 public:
-    RacInput40(FILE *file) : RacInput<RacConfig40, RacFileIO>(RacFileIO(file)) { }
+    RacOutput40(IO io) : RacOutput<RacConfig40, IO>(io) { }
 };
 
-class RacOutput40 : public RacOutput<RacConfig40, RacFileIO>
+template <typename IO> class RacInput24 : public RacInput<RacConfig24, IO>
 {
 public:
-    RacOutput40(FILE *file) : RacOutput<RacConfig40, RacFileIO>(RacFileIO(file)) { }
+    RacInput24(IO io) : RacInput<RacConfig24, IO>(io) { }
 };
 
-class RacInput24 : public RacInput<RacConfig24, RacFileIO>
+template <typename IO> class RacOutput24 : public RacOutput<RacConfig24, IO>
 {
 public:
-    RacInput24(FILE *file) : RacInput<RacConfig24, RacFileIO>(RacFileIO(file)) { }
-};
-
-class RacOutput24 : public RacOutput<RacConfig24, RacFileIO>
-{
-public:
-    RacOutput24(FILE *file) : RacOutput<RacConfig24, RacFileIO>(RacFileIO(file)) { }
+    RacOutput24(IO io) : RacOutput<RacConfig24, IO>(io) { }
 };
 
 #endif

--- a/transform/bounds.h
+++ b/transform/bounds.h
@@ -27,7 +27,8 @@ public:
 };
 
 
-class TransformBounds : public Transform {
+template <typename IO>
+class TransformBounds : public Transform<IO> {
 protected:
     std::vector<std::pair<ColorVal, ColorVal> > bounds;
 
@@ -39,8 +40,8 @@ protected:
         }
     }
 
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<SimpleBitChance, RacIn, 24> coder(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<SimpleBitChance, RacIn<IO>, 24> coder(rac);
         bounds.clear();
         for (int p=0; p<srcRanges->numPlanes(); p++) {
 //            ColorVal min = coder.read_int(0, srcRanges->max(p) - srcRanges->min(p)) + srcRanges->min(p);
@@ -52,8 +53,8 @@ protected:
         }
     }
 
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<SimpleBitChance, RacOut, 24> coder(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<SimpleBitChance, RacOut<IO>, 24> coder(rac);
         for (int p=0; p<srcRanges->numPlanes(); p++) {
             ColorVal min = bounds[p].first;
             ColorVal max = bounds[p].second;

--- a/transform/colorbuckets.h
+++ b/transform/colorbuckets.h
@@ -279,7 +279,8 @@ public:
 };
 
 
-class TransformCB : public Transform {
+template <typename IO>
+class TransformCB : public Transform<IO> {
 protected:
     ColorBuckets *cb;
 
@@ -350,7 +351,7 @@ protected:
         }
     }
 
-    ColorBucket load_bucket(SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) {
+    ColorBucket load_bucket(SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) {
         ColorBucket b;
         if (plane<3)
         for (int p=0; p<plane; p++) {
@@ -394,9 +395,9 @@ protected:
 //        b.print();
         return b;
     }
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
 //        printf("Loading Color Buckets\n");
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coder(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coder(rac);
         prevPlanes pixelL, pixelU;
         cb->bucket0 = load_bucket(coder, srcRanges, 0, pixelL, pixelU);
         pixelL.push_back(cb->min0);
@@ -418,7 +419,7 @@ protected:
         if (srcRanges->numPlanes() > 3) cb->bucket3 = load_bucket(coder, srcRanges, 3, pixelL, pixelU);
     }
 
-    void save_bucket(const ColorBucket &b, SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) const {
+    void save_bucket(const ColorBucket &b, SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> &coder, const ColorRanges *srcRanges, const int plane, const prevPlanes &pixelL, const prevPlanes &pixelU) const {
         if (plane<3)
         for (int p=0; p<plane; p++) {
                 if (!cb->exists(p,pixelL,pixelU)) {
@@ -465,8 +466,8 @@ protected:
              }
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coder(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coder(rac);
 
 //        printf("Saving Y Color Bucket: ");
         prevPlanes pixelL, pixelU;

--- a/transform/factory.cpp
+++ b/transform/factory.cpp
@@ -11,23 +11,26 @@
 #include "framedup.h"
 #include "framecombine.h"
 
-Transform *create_transform(std::string desc)
+template <typename IO>
+Transform<IO> *create_transform(std::string desc)
 {
     if (desc == "YIQ")
-        return new TransformYIQ();
+        return new TransformYIQ<IO>();
     if (desc == "BND")
-        return new TransformBounds();
+        return new TransformBounds<IO>();
     if (desc == "ACB")
-        return new TransformCB();
+        return new TransformCB<IO>();
     if (desc == "PLT")
-        return new TransformPalette();
+        return new TransformPalette<IO>();
     if (desc == "PLA")
-        return new TransformPaletteA();
+        return new TransformPaletteA<IO>();
     if (desc == "FRS")
-        return new TransformFrameShape();
+        return new TransformFrameShape<IO>();
     if (desc == "DUP")
-        return new TransformFrameDup();
+        return new TransformFrameDup<IO>();
     if (desc == "FRA")
-        return new TransformFrameCombine();
+        return new TransformFrameCombine<IO>();
     return NULL;
 }
+
+template Transform<FileIO> *create_transform(std::string desc);

--- a/transform/factory.h
+++ b/transform/factory.h
@@ -4,6 +4,7 @@
 #include "transform.h"
 #include <string>
 
-Transform *create_transform(std::string desc);
+template <typename IO>
+Transform<IO> *create_transform(std::string desc);
 
 #endif

--- a/transform/framecombine.h
+++ b/transform/framecombine.h
@@ -24,7 +24,8 @@ public:
     }
 };
 
-class TransformFrameCombine : public Transform {
+template <typename IO>
+class TransformFrameCombine : public Transform<IO> {
 protected:
     bool was_flat;
     int max_lookback;
@@ -41,14 +42,14 @@ protected:
         return new ColorRangesFC(lookback, (srcRanges->numPlanes() == 4 ? srcRanges->max(3) : 1), srcRanges);
     }
 
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<SimpleBitChance, RacIn, 24> coder(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<SimpleBitChance, RacIn<IO>, 24> coder(rac);
         max_lookback = coder.read_int(1, 256);
         v_printf(5,"[%i]",max_lookback);
     }
 
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<SimpleBitChance, RacOut, 24> coder(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<SimpleBitChance, RacOut<IO>, 24> coder(rac);
         coder.write_int(1,256,max_lookback);
     }
 

--- a/transform/framedup.h
+++ b/transform/framedup.h
@@ -8,7 +8,8 @@
 
 
 
-class TransformFrameDup : public Transform {
+template <typename IO>
+class TransformFrameDup : public Transform<IO> {
 protected:
     std::vector<int> seen_before;
     uint32_t nb;
@@ -23,16 +24,16 @@ protected:
 
     void configure(const int setting) { nb=setting; }
 
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coder(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coder(rac);
         seen_before.clear();
         seen_before.push_back(-1);
         for (unsigned int i=1; i<nb; i++) seen_before.push_back(coder.read_int(-1,nb-2));
         int count=0; for(int i : seen_before) { if(i>=0) count++; } v_printf(5,"[%i]",count);
     }
 
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coder(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coder(rac);
         assert(nb == seen_before.size());
         for (unsigned int i=1; i<seen_before.size(); i++) coder.write_int(-1,nb-2,seen_before[i]);
         int count=0; for(int i : seen_before) { if(i>=0) count++; } v_printf(5,"[%i]",count);

--- a/transform/frameshape.h
+++ b/transform/frameshape.h
@@ -8,7 +8,8 @@
 
 
 
-class TransformFrameShape : public Transform {
+template <typename IO>
+class TransformFrameShape : public Transform<IO> {
 protected:
     std::vector<uint32_t> b;
     std::vector<uint32_t> e;
@@ -32,15 +33,15 @@ protected:
 
     void configure(const int setting) { if (nb==0) nb=setting; else cols=setting; } // ok this is dirty
 
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coder(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coder(rac);
         for (unsigned int i=0; i<nb; i+=1) {b.push_back(coder.read_int(0,cols));}
         for (unsigned int i=0; i<nb; i+=1) {e.push_back(cols-coder.read_int(0,cols-b[i]));}
 //        for (unsigned int i=0; i<nb; i+=1) {e.push_back(coder.read_int(b[i],cols));}
     }
 
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coder(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coder(rac);
         assert(nb == b.size());
         assert(nb == e.size());
         for (unsigned int i=0; i<nb; i+=1) { coder.write_int(0,cols,b[i]); }

--- a/transform/palette.h
+++ b/transform/palette.h
@@ -36,7 +36,8 @@ public:
 };
 
 
-class TransformPalette : public Transform {
+template <typename IO>
+class TransformPalette : public Transform<IO> {
 protected:
     typedef std::tuple<ColorVal,ColorVal,ColorVal> Color;
     std::set<Color> Palette;
@@ -99,11 +100,11 @@ public:
           image.palette=false;
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coder(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderY(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderI(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderQ(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coder(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderY(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderI(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderQ(rac);
         Color min(srcRanges->min(0), srcRanges->min(1), srcRanges->min(2));
         Color max(srcRanges->max(0), srcRanges->max(1), srcRanges->max(2));
         coder.write_int(1, MAX_PALETTE_SIZE, Palette_vector.size());
@@ -125,11 +126,11 @@ public:
 //        printf("\nSaved palette of size: %lu\n",Palette_vector.size());
         v_printf(5,"[%lu]",Palette_vector.size());
     }
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coder(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderY(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderI(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderQ(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coder(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderY(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderI(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderQ(rac);
         Color min(srcRanges->min(0), srcRanges->min(1), srcRanges->min(2));
         Color max(srcRanges->max(0), srcRanges->max(1), srcRanges->max(2));
         long unsigned size = coder.read_int(1, MAX_PALETTE_SIZE);

--- a/transform/palette_A.h
+++ b/transform/palette_A.h
@@ -38,7 +38,8 @@ public:
 };
 
 
-class TransformPaletteA : public Transform {
+template <typename IO>
+class TransformPaletteA : public Transform<IO> {
 protected:
     typedef std::tuple<ColorVal,ColorVal,ColorVal,ColorVal> Color;
     std::set<Color> Palette;
@@ -104,12 +105,12 @@ public:
           image.palette=false;
         }
     }
-    void save(const ColorRanges *srcRanges, RacOut &rac) const {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coder(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderY(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderI(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderQ(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut, 24> coderA(rac);
+    void save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coder(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderY(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderI(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderQ(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacOut<IO>, 24> coderA(rac);
         Color min(srcRanges->min(3), srcRanges->min(0), srcRanges->min(1), srcRanges->min(2));
         Color max(srcRanges->max(3), srcRanges->max(0), srcRanges->max(1), srcRanges->max(2));
         coder.write_int(1, MAX_PALETTE_SIZE, Palette_vector.size());
@@ -135,12 +136,12 @@ public:
 //        printf("\nSaved palette of size: %lu\n",Palette_vector.size());
         v_printf(5,"[%lu]",Palette_vector.size());
     }
-    void load(const ColorRanges *srcRanges, RacIn &rac) {
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coder(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderY(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderI(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderQ(rac);
-        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn, 24> coderA(rac);
+    void load(const ColorRanges *srcRanges, RacIn<IO> &rac) {
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coder(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderY(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderI(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderQ(rac);
+        SimpleSymbolCoder<FLIFBitChanceMeta, RacIn<IO>, 24> coderA(rac);
         Color min(srcRanges->min(3), srcRanges->min(0), srcRanges->min(1), srcRanges->min(2));
         Color max(srcRanges->max(3), srcRanges->max(0), srcRanges->max(1), srcRanges->max(2));
         long unsigned size = coder.read_int(1, MAX_PALETTE_SIZE);

--- a/transform/transform.h
+++ b/transform/transform.h
@@ -8,6 +8,7 @@
 #include "../common.h"
 
 
+template <typename IO>
 class Transform {
 protected:
 
@@ -20,8 +21,8 @@ public:
     bool virtual init(const ColorRanges *srcRanges) { return true; }
     void virtual configure(const int setting) { }
     bool virtual process(const ColorRanges *srcRanges, const Images &images) { return true; };
-    void virtual load(const ColorRanges *srcRanges, RacIn &rac) {};
-    void virtual save(const ColorRanges *srcRanges, RacOut &rac) const {};
+    void virtual load(const ColorRanges *srcRanges, RacIn<IO> &rac) {};
+    void virtual save(const ColorRanges *srcRanges, RacOut<IO> &rac) const {};
     const ColorRanges virtual *meta(Images& images, const ColorRanges *srcRanges) { return new DupColorRanges(srcRanges); }
     void virtual data(Images& images) const {}
     void virtual invData(Images& images) const {}

--- a/transform/yiq.h
+++ b/transform/yiq.h
@@ -108,7 +108,8 @@ public:
 };
 
 
-class TransformYIQ : public Transform {
+template <typename IO>
+class TransformYIQ : public Transform<IO> {
 protected:
     int par;
 


### PR DESCRIPTION
All the file IO is now in a single file called `fileio.h` and a bit in `flif.cpp`.

The rest of the code uses a zero-overhead template parameter called `IO`.

The idea is that `IO` could be implemented in different ways. In the `emscripten` port, this will allow me to implement an in-memory buffer for the input, rather than emulating a POSIX file-system in Javascript.